### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Add the following to enable Currents MCP on Claude Desktop (edit `claude_desktop
 
 By connecting AI tools (e.g., via MCP) to Currents, you are granting them access to your API key, test results and CI metadata. It is your responsibility to vet any AI agents or services you use, and to ensure they handle your data securely.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/currents-dev-currents-mcp).
+
 ## References
 
 - [Currents](https://currents.dev)


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/currents-dev-currents-mcp).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Hosted deployment section to the README with a link to the Currents MCP deployment on Fronteir AI, giving users a quick hosted option without self-hosting.

<sup>Written for commit 17bee3d8dd8827b566f5329604a9d78ee6d3106b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

