### PR TITLE
fix(mcp-server): point types metadata to emitted declarations

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -18,10 +18,10 @@
   "description": "Currents MCP server",
   "main": "./dist/api.cjs",
   "module": "./dist/api.mjs",
-  "types": "./dist/api.d.ts",
+  "types": "./dist/api.d.mts",
   "exports": {
     ".": {
-      "types": "./dist/api.d.ts",
+      "types": "./dist/api.d.mts",
       "import": "./dist/api.mjs",
       "require": "./dist/api.cjs"
     }

--- a/mcp-server/src/cli-bin.integration.test.ts
+++ b/mcp-server/src/cli-bin.integration.test.ts
@@ -12,19 +12,19 @@
  *    (same artifact shape as registry install, minus release-only publish.cjs
  *    mutations).
  */
-import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { execNpm, spawnNpx } from "../test/npm-exec.js";
 
 const root = fileURLToPath(new URL("..", import.meta.url));
 const buildIndex = path.join(root, "dist", "index.mjs");
 
 function packTarball(packDest: string): string {
   // Respect `files` and standard pack rules; do not mutate package.json (unlike release `publish.cjs`).
-  execFileSync("npm", ["pack", "--ignore-scripts", "--pack-destination", packDest], {
+  execNpm(["pack", "--ignore-scripts", "--pack-destination", packDest], {
     cwd: root,
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -50,7 +50,7 @@ describe.skipIf(!existsSync(buildIndex))(
     it("starts via npx --package tarball mcp", () => {
       const packDir = mkdtempSync(path.join(tmpdir(), "mcp-pack-"));
       const tarball = packTarball(packDir);
-      const r = spawnSync("npx", ["-y", "--package", tarball, "mcp"], {
+      const r = spawnNpx(["-y", "--package", tarball, "mcp"], {
         cwd: packDir,
         timeout: 45_000,
         encoding: "utf-8",
@@ -80,11 +80,11 @@ describe.skipIf(!existsSync(buildIndex))(
       const packDir = mkdtempSync(path.join(tmpdir(), "mcp-pack-"));
       const installDir = mkdtempSync(path.join(tmpdir(), "mcp-install-"));
       const tarball = packTarball(packDir);
-      execFileSync("npm", ["init", "-y"], {
+      execNpm(["init", "-y"], {
         cwd: installDir,
         stdio: "ignore",
       });
-      execFileSync("npm", ["install", tarball], {
+      execNpm(["install", tarball], {
         cwd: installDir,
         stdio: "ignore",
       });

--- a/mcp-server/src/package-published-esm.integration.test.ts
+++ b/mcp-server/src/package-published-esm.integration.test.ts
@@ -29,11 +29,18 @@
  *    layout.
  * */
 import { execFileSync } from "node:child_process";
-import { copyFileSync, existsSync, mkdtempSync, readdirSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { execNpm } from "../test/npm-exec.js";
 
 const root = fileURLToPath(new URL("..", import.meta.url));
 const buildIndex = path.join(root, "dist", "index.mjs");
@@ -41,7 +48,7 @@ const buildIndex = path.join(root, "dist", "index.mjs");
 /** Run `npm pack` from the package root and return the path to the single `.tgz` in `packDest`. */
 function packTarball(packDest: string): string {
   // Respect `files` and standard pack rules; do not mutate package.json (unlike release `publish.cjs`).
-  execFileSync("npm", ["pack", "--ignore-scripts", "--pack-destination", packDest], {
+  execNpm(["pack", "--ignore-scripts", "--pack-destination", packDest], {
     cwd: root,
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -62,11 +69,11 @@ describe.skipIf(!existsSync(buildIndex))(
         path.join(tmpdir(), "mcp-install-published-")
       );
       const tarball = packTarball(packDir);
-      execFileSync("npm", ["init", "-y"], {
+      execNpm(["init", "-y"], {
         cwd: installDir,
         stdio: "ignore",
       });
-      execFileSync("npm", ["install", tarball], {
+      execNpm(["install", tarball], {
         cwd: installDir,
         stdio: "ignore",
       });
@@ -83,6 +90,33 @@ describe.skipIf(!existsSync(buildIndex))(
         encoding: "utf-8",
       });
       expect(out.trim()).toBe("published-esm-ok");
+    });
+
+    it("ships package metadata that points at existing declaration files", () => {
+      const packDir = mkdtempSync(path.join(tmpdir(), "mcp-pack-types-"));
+      const installDir = mkdtempSync(path.join(tmpdir(), "mcp-install-types-"));
+      const tarball = packTarball(packDir);
+      execNpm(["init", "-y"], {
+        cwd: installDir,
+        stdio: "ignore",
+      });
+      execNpm(["install", tarball], {
+        cwd: installDir,
+        stdio: "ignore",
+      });
+      const installedRoot = path.join(
+        installDir,
+        "node_modules",
+        "@currents",
+        "mcp"
+      );
+      const pkg = JSON.parse(
+        readFileSync(path.join(installedRoot, "package.json"), "utf-8")
+      );
+      expect(existsSync(path.join(installedRoot, pkg.types))).toBe(true);
+      expect(existsSync(path.join(installedRoot, pkg.exports["."].types))).toBe(
+        true
+      );
     });
   }
 );

--- a/mcp-server/test/npm-exec.ts
+++ b/mcp-server/test/npm-exec.ts
@@ -1,0 +1,26 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const npmCli = process.env.npm_execpath;
+const npxCli = npmCli ? path.join(path.dirname(npmCli), "npx-cli.js") : undefined;
+
+export function execNpm(
+  args: string[],
+  options: Parameters<typeof execFileSync>[2]
+) {
+  if (npmCli) {
+    return execFileSync(process.execPath, [npmCli, ...args], options);
+  }
+  return execFileSync("npm", args, options);
+}
+
+export function spawnNpx(
+  args: string[],
+  options: Parameters<typeof spawnSync>[2]
+) {
+  if (npxCli && existsSync(npxCli)) {
+    return spawnSync(process.execPath, [npxCli, ...args], options);
+  }
+  return spawnSync("npx", args, options);
+}

--- a/mcp-server/test/npm-exec.ts
+++ b/mcp-server/test/npm-exec.ts
@@ -9,7 +9,7 @@ export function execNpm(
   args: string[],
   options: Parameters<typeof execFileSync>[2]
 ) {
-  if (npmCli) {
+  if (npmCli && existsSync(npmCli)) {
     return execFileSync(process.execPath, [npmCli, ...args], options);
   }
   return execFileSync("npm", args, options);


### PR DESCRIPTION
## Summary
- point package `types` and exported `types` to the emitted `dist/api.d.mts`
- add pack/install integration coverage that checks metadata declaration paths exist
- invoke npm/npx through the current Node runtime in integration tests when available, which keeps the tests working on Windows

## Validation
- `npm ci --ignore-scripts`
- `npx tsdown`
- `npx vitest run src/package-published-esm.integration.test.ts`
- `npx tsdown`; `npx vitest run` (12 files / 385 tests)
- `npm pack --ignore-scripts` plus clean temp install metadata smoke

Note: `npm run build` runs `tsdown` successfully here, then fails on Windows at the existing POSIX `chmod 755 dist/index.mjs` step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched package type declaration mappings to ESM-compatible declaration files for proper ESM typing resolution.

* **Tests**
  * Centralized npm/npx invocation in test helpers for more reliable command execution.
  * Improved integration tests and added a new test that verifies bundled type declaration paths are present and correctly referenced after packaging/install.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->