### PR TITLE
Add currents-get-test-evidence tool and collect-ci-evidence skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,46 +13,55 @@ Give your AI coding agents full visibility into your CI test results. The Curren
 
 ## Tools
 
-| Tool                                    | Description                                                                               |
-| --------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `currents-list-actions`                 | List all actions for a project with optional filtering.                                   |
-| `currents-create-action`                | Create a new action for a project.                                                        |
-| `currents-get-action`                   | Get a single action by ID.                                                                |
-| `currents-update-action`                | Update an existing action.                                                                |
-| `currents-delete-action`                | Delete (archive) an action.                                                               |
-| `currents-enable-action`                | Enable a disabled action.                                                                 |
-| `currents-disable-action`               | Disable an active action.                                                                 |
-| `currents-list-affected-tests`          | List tests affected by actions (quarantine, skip, tag) for a project within a date range. |
-| `currents-get-affected-test-executions` | Get execution details for a specific affected test (by signature) within a date range.    |
-| `currents-get-affected-executions`      | List test executions where a specific action/rule was applied, within a date range.       |
-| `currents-get-projects`                 | Retrieves projects available in the Currents platform.                                    |
-| `currents-get-project`                  | Get a single project by ID.                                                               |
-| `currents-get-project-insights`         | Get aggregated run and test metrics for a project within a date range.                    |
-| `currents-list-pull-requests`           | List pull-request cards for a project (runs grouped by meta.pr.id).                       |
-| `currents-list-project-terms`           | List cursor-paginated project terms for one type (tag, branch, authorName, etc.).         |
-| `currents-create-jira-issue`            | Create a Jira issue from a run test using the organization Jira integration.              |
-| `currents-link-jira-issue`              | Link an existing Jira issue to a run test using the organization Jira integration.        |
-| `currents-list-jira-projects`           | List Jira projects available for the organization integration.                            |
-| `currents-list-jira-issue-types`        | List Jira issue types and custom fields for a Jira project.                               |
-| `currents-get-runs`                     | Retrieves a list of runs for a specific project with optional filtering.                  |
-| `currents-get-run-details`              | Retrieves details of a specific test run.                                                 |
-| `currents-find-run`                     | Find a run by query parameters.                                                           |
-| `currents-cancel-run`                   | Cancel a run in progress.                                                                 |
-| `currents-reset-run`                    | Reset failed spec files in a run to allow re-execution.                                   |
-| `currents-delete-run`                   | Delete a run and all associated data.                                                     |
-| `currents-cancel-run-github-ci`         | Cancel a run by GitHub Actions workflow run ID and attempt number.                        |
-| `currents-get-spec-instance`            | Retrieves debugging data from a specific execution of a test spec file by instanceId.     |
-| `currents-get-spec-files-performance`   | Retrieves spec files performance metrics for a specific project within a date range.      |
-| `currents-get-tests-performance`        | Retrieves aggregated test metrics for a specific project within a date range.             |
-| `currents-get-tests-signatures`         | Generates a unique test signature based on project, spec file path, and test title.       |
-| `currents-get-test-results`             | Retrieves historical test execution results for a specific test signature.                |
-| `currents-get-context`                  | Get test failure context for AI debugging at run, instance, or test level.                |
-| `currents-get-errors-explorer`          | Get aggregated error metrics for a project within a date range.                           |
-| `currents-list-webhooks`                | List all webhooks for a project.                                                          |
-| `currents-create-webhook`               | Create a new webhook for a project.                                                       |
-| `currents-get-webhook`                  | Get a single webhook by ID.                                                               |
-| `currents-update-webhook`               | Update an existing webhook.                                                               |
-| `currents-delete-webhook`               | Delete a webhook.                                                                         |
+| Tool                                    | Description                                                                                                                                      |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `currents-list-actions`                 | List all actions for a project with optional filtering.                                                                                          |
+| `currents-create-action`                | Create a new action for a project.                                                                                                               |
+| `currents-get-action`                   | Get a single action by ID.                                                                                                                       |
+| `currents-update-action`                | Update an existing action.                                                                                                                       |
+| `currents-delete-action`                | Delete (archive) an action.                                                                                                                      |
+| `currents-enable-action`                | Enable a disabled action.                                                                                                                        |
+| `currents-disable-action`               | Disable an active action.                                                                                                                        |
+| `currents-list-affected-tests`          | List tests affected by actions (quarantine, skip, tag) for a project within a date range.                                                        |
+| `currents-get-affected-test-executions` | Get execution details for a specific affected test (by signature) within a date range.                                                           |
+| `currents-get-affected-executions`      | List test executions where a specific action/rule was applied, within a date range.                                                              |
+| `currents-get-projects`                 | Retrieves projects available in the Currents platform.                                                                                           |
+| `currents-get-project`                  | Get a single project by ID.                                                                                                                      |
+| `currents-get-project-insights`         | Get aggregated run and test metrics for a project within a date range.                                                                           |
+| `currents-list-pull-requests`           | List pull-request cards for a project (runs grouped by meta.pr.id).                                                                              |
+| `currents-list-project-terms`           | List cursor-paginated project terms for one type (tag, branch, authorName, etc.).                                                                |
+| `currents-create-jira-issue`            | Create a Jira issue from a run test using the organization Jira integration.                                                                     |
+| `currents-link-jira-issue`              | Link an existing Jira issue to a run test using the organization Jira integration.                                                               |
+| `currents-list-jira-projects`           | List Jira projects available for the organization integration.                                                                                   |
+| `currents-list-jira-issue-types`        | List Jira issue types and custom fields for a Jira project.                                                                                      |
+| `currents-get-runs`                     | Retrieves a list of runs for a specific project with optional filtering.                                                                         |
+| `currents-get-run-details`              | Retrieves details of a specific test run.                                                                                                        |
+| `currents-find-run`                     | Find a run by query parameters.                                                                                                                  |
+| `currents-cancel-run`                   | Cancel a run in progress.                                                                                                                        |
+| `currents-reset-run`                    | Reset failed spec files in a run to allow re-execution.                                                                                          |
+| `currents-delete-run`                   | Delete a run and all associated data.                                                                                                            |
+| `currents-cancel-run-github-ci`         | Cancel a run by GitHub Actions workflow run ID and attempt number.                                                                               |
+| `currents-get-spec-instance`            | Retrieves debugging data from a specific execution of a test spec file by instanceId.                                                            |
+| `currents-get-spec-files-performance`   | Retrieves spec files performance metrics for a specific project within a date range.                                                             |
+| `currents-get-tests-performance`        | Retrieves aggregated test metrics for a specific project within a date range.                                                                    |
+| `currents-get-tests-signatures`         | Generates a unique test signature based on project, spec file path, and test title.                                                              |
+| `currents-get-test-results`             | Retrieves historical test execution results for a specific test signature.                                                                       |
+| `currents-get-context`                  | Get test failure context for AI debugging at run, instance, or test level.                                                                       |
+| `currents-get-errors-explorer`          | Get aggregated error metrics for a project within a date range.                                                                                  |
+| `currents-get-test-evidence`            | Collect evidence artifacts (screenshots, videos, traces, attachments) produced by tests in a CI run, with signed download URLs grouped per test. |
+| `currents-list-webhooks`                | List all webhooks for a project.                                                                                                                 |
+| `currents-create-webhook`               | Create a new webhook for a project.                                                                                                              |
+| `currents-get-webhook`                  | Get a single webhook by ID.                                                                                                                      |
+| `currents-update-webhook`               | Update an existing webhook.                                                                                                                      |
+| `currents-delete-webhook`               | Delete a webhook.                                                                                                                                |
+
+## Skills
+
+Agent skills that teach AI agents multi-step Currents workflows. Copy a skill directory into your agent's skills location (e.g. `.claude/skills/` for Claude Code).
+
+| Skill                                              | Description                                                                                                                        |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [`collect-ci-evidence`](skills/collect-ci-evidence) | Collect evidence or a demo of an implemented feature from CI test runs — before/after screenshots, text attachments, videos, traces. |
 
 ## Setup
 

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -46,6 +46,8 @@ import { getTestsPerformanceTool } from "./tools/tests/get-tests-performance.js"
 import { getTestSignatureTool } from "./tools/tests/get-tests-signature.js";
 // Errors tools
 import { getErrorsExplorerTool } from "./tools/errors/get-errors-explorer.js";
+// Evidence tools
+import { getTestEvidenceTool } from "./tools/evidence/get-test-evidence.js";
 // Webhooks tools
 import { createWebhookTool } from "./tools/webhooks/create-webhook.js";
 import { deleteWebhookTool } from "./tools/webhooks/delete-webhook.js";
@@ -416,6 +418,17 @@ server.registerTool(
     inputSchema: getErrorsExplorerTool.schema,
   },
   getErrorsExplorerTool.handler,
+);
+
+// Evidence tools
+server.registerTool(
+  "currents-get-test-evidence",
+  {
+    description:
+      "Collect evidence artifacts (screenshots, videos, traces, attachments) produced by tests in a CI run, with signed download URLs grouped per test. Use to gather proof or a demo of an implemented feature from CI — e.g. before/after screenshots, text output stored as test attachments, or Playwright videos and traces — instead of running tests locally. Locates the run by runId, or by projectId with ciBuildId or branch (latest run). Supports filtering by spec file, test title, and test status. URLs are signed and time-limited, so download the files promptly.",
+    inputSchema: getTestEvidenceTool.schema,
+  },
+  getTestEvidenceTool.handler,
 );
 
 // Webhooks API tools

--- a/mcp-server/src/tools/evidence/get-test-evidence.test.ts
+++ b/mcp-server/src/tools/evidence/get-test-evidence.test.ts
@@ -109,6 +109,25 @@ describe("getTestEvidenceTool", () => {
     expect(manifest.run.dashboardUrl).toBe("https://app.currents.dev/run/run-1");
   });
 
+  it("omits branch from /runs/find when ciBuildId is given", async () => {
+    vi.mocked(request.fetchApi).mockImplementation(async (path: string) => {
+      if (path.startsWith("/runs/find")) return { data: { runId: "run-1" } };
+      if (path === "/runs/run-1") return runPayload;
+      if (path.startsWith("/instances/")) return instancePayload;
+      return null;
+    });
+
+    await getTestEvidenceTool.handler({
+      projectId: "p1",
+      ciBuildId: "build-42",
+      branch: "feature-x",
+    });
+
+    const findUrl = vi.mocked(request.fetchApi).mock.calls[0][0] as string;
+    expect(findUrl).toContain("ciBuildId=build-42");
+    expect(findUrl).not.toContain("branch");
+  });
+
   it("groups artifacts by test and separates spec-level evidence", async () => {
     vi.mocked(request.fetchApi).mockImplementation(async (path: string) => {
       if (path === "/runs/run-1") return runPayload;

--- a/mcp-server/src/tools/evidence/get-test-evidence.test.ts
+++ b/mcp-server/src/tools/evidence/get-test-evidence.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as request from "../../lib/request.js";
+import { getTestEvidenceTool } from "./get-test-evidence.js";
+
+vi.mock("../../lib/request.js");
+
+const runPayload = {
+  data: {
+    runId: "run-1",
+    projectId: "p1",
+    createdAt: "2026-08-01T00:00:00Z",
+    status: "PASSED",
+    meta: {
+      ciBuildId: "build-42",
+      commit: { branch: "feature-x", sha: "abc123" },
+    },
+    specs: [
+      { instanceId: "inst-1", spec: "e2e/checkout.spec.ts" },
+      { instanceId: "inst-2", spec: "e2e/login.spec.ts" },
+    ],
+  },
+};
+
+const instancePayload = {
+  data: {
+    instanceId: "inst-1",
+    results: {
+      tests: [
+        {
+          testId: "t1",
+          title: ["Checkout", "shows order summary"],
+          state: "passed",
+        },
+        { testId: "t2", title: ["Checkout", "applies coupon"], state: "failed" },
+      ],
+      screenshots: [
+        {
+          testId: "t1",
+          screenshotId: "s1",
+          name: "after-checkout",
+          testAttemptIndex: 0,
+          screenshotURL: "https://signed/screenshot1.png",
+        },
+      ],
+      videos: [
+        { testId: "t1", testAttemptIndex: 0, videoUrl: "https://signed/video1.webm" },
+      ],
+      playwrightTraces: [
+        {
+          testId: "t2",
+          traceId: "tr1",
+          name: "trace",
+          testAttemptIndex: 1,
+          traceURL: "https://signed/trace1.zip",
+        },
+      ],
+      attachments: [
+        {
+          testId: "t1",
+          testAttemptIndex: 0,
+          name: "before.txt",
+          filename: "before.txt",
+          contentType: "text/plain",
+          readUrl: "https://signed/before.txt",
+        },
+        // no testId: spec-level attachment
+        { name: "report.json", readUrl: "https://signed/report.json" },
+      ],
+      videoUrl: "https://signed/spec-video.mp4",
+    },
+  },
+};
+
+const parseManifest = (result: { content: { text: string }[] }) =>
+  JSON.parse(result.content[0].text);
+
+describe("getTestEvidenceTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires runId or projectId", async () => {
+    const result = await getTestEvidenceTool.handler({});
+    expect(result.content[0].text).toContain("runId or projectId");
+    expect(request.fetchApi).not.toHaveBeenCalled();
+  });
+
+  it("resolves the run via /runs/find when only projectId and branch are given", async () => {
+    vi.mocked(request.fetchApi).mockImplementation(async (path: string) => {
+      if (path.startsWith("/runs/find")) return { data: { runId: "run-1" } };
+      if (path === "/runs/run-1") return runPayload;
+      if (path.startsWith("/instances/")) return instancePayload;
+      return null;
+    });
+
+    const result = await getTestEvidenceTool.handler({
+      projectId: "p1",
+      branch: "feature-x",
+    });
+
+    const findUrl = vi.mocked(request.fetchApi).mock.calls[0][0] as string;
+    expect(findUrl).toContain("/runs/find");
+    expect(findUrl).toContain("projectId=p1");
+    expect(findUrl).toContain("branch=feature-x");
+
+    const manifest = parseManifest(result);
+    expect(manifest.run.runId).toBe("run-1");
+    expect(manifest.run.branch).toBe("feature-x");
+    expect(manifest.run.dashboardUrl).toBe("https://app.currents.dev/run/run-1");
+  });
+
+  it("groups artifacts by test and separates spec-level evidence", async () => {
+    vi.mocked(request.fetchApi).mockImplementation(async (path: string) => {
+      if (path === "/runs/run-1") return runPayload;
+      if (path.startsWith("/instances/")) return instancePayload;
+      return null;
+    });
+
+    const result = await getTestEvidenceTool.handler({
+      runId: "run-1",
+      spec: "checkout",
+    });
+
+    const manifest = parseManifest(result);
+    expect(manifest.specs).toHaveLength(1);
+    const specEntry = manifest.specs[0];
+    expect(specEntry.spec).toBe("e2e/checkout.spec.ts");
+
+    const t1 = specEntry.tests.find((t: any) => t.testId === "t1");
+    expect(t1.title).toBe("Checkout > shows order summary");
+    expect(t1.status).toBe("passed");
+    expect(t1.evidence.screenshots).toEqual([
+      { name: "after-checkout", attempt: 0, url: "https://signed/screenshot1.png" },
+    ]);
+    expect(t1.evidence.videos).toHaveLength(1);
+    expect(t1.evidence.attachments[0].contentType).toBe("text/plain");
+
+    const t2 = specEntry.tests.find((t: any) => t.testId === "t2");
+    expect(t2.evidence.traces).toEqual([
+      { name: "trace", attempt: 1, url: "https://signed/trace1.zip" },
+    ]);
+
+    // spec-level: attachment without testId + Cypress spec video
+    expect(specEntry.specLevelEvidence.attachments[0].name).toBe("report.json");
+    expect(
+      specEntry.specLevelEvidence.videos.some(
+        (v: any) => v.url === "https://signed/spec-video.mp4"
+      )
+    ).toBe(true);
+  });
+
+  it("filters tests by title and status", async () => {
+    vi.mocked(request.fetchApi).mockImplementation(async (path: string) => {
+      if (path === "/runs/run-1") return runPayload;
+      if (path.startsWith("/instances/")) return instancePayload;
+      return null;
+    });
+
+    const result = await getTestEvidenceTool.handler({
+      runId: "run-1",
+      spec: "checkout",
+      testTitle: "coupon",
+      testStatus: ["failed"],
+    });
+
+    const manifest = parseManifest(result);
+    const tests = manifest.specs[0].tests;
+    expect(tests).toHaveLength(1);
+    expect(tests[0].testId).toBe("t2");
+  });
+
+  it("lists available spec files when the spec filter matches nothing", async () => {
+    vi.mocked(request.fetchApi).mockImplementation(async (path: string) => {
+      if (path === "/runs/run-1") return runPayload;
+      return null;
+    });
+
+    const result = await getTestEvidenceTool.handler({
+      runId: "run-1",
+      spec: "does-not-exist",
+    });
+
+    expect(result.content[0].text).toContain("No spec files matching");
+    expect(result.content[0].text).toContain("e2e/checkout.spec.ts");
+    expect(result.content[0].text).toContain("e2e/login.spec.ts");
+  });
+
+  it("reports when no run is found", async () => {
+    vi.mocked(request.fetchApi).mockResolvedValue(null);
+
+    const result = await getTestEvidenceTool.handler({
+      projectId: "p1",
+      ciBuildId: "missing-build",
+    });
+
+    expect(result.content[0].text).toContain("No run found");
+    expect(result.content[0].text).toContain("ciBuildId=missing-build");
+  });
+});

--- a/mcp-server/src/tools/evidence/get-test-evidence.ts
+++ b/mcp-server/src/tools/evidence/get-test-evidence.ts
@@ -172,7 +172,7 @@ const handler = async ({
     const queryParams = new URLSearchParams();
     queryParams.append("projectId", projectId as string);
     if (ciBuildId) queryParams.append("ciBuildId", ciBuildId);
-    if (branch) queryParams.append("branch", branch);
+    else if (branch) queryParams.append("branch", branch);
     const found = await fetchApi<{ data?: { runId?: string } }>(
       `/runs/find?${queryParams.toString()}`
     );

--- a/mcp-server/src/tools/evidence/get-test-evidence.ts
+++ b/mcp-server/src/tools/evidence/get-test-evidence.ts
@@ -1,0 +1,306 @@
+import { z } from "zod";
+import { fetchApi } from "../../lib/request.js";
+import { logger } from "../../lib/logger.js";
+
+const zodSchema = z.object({
+  projectId: z
+    .string()
+    .optional()
+    .describe(
+      "The project ID. Required unless runId is provided. Used to locate the run by ciBuildId or branch."
+    ),
+  runId: z
+    .string()
+    .optional()
+    .describe(
+      "The run ID to collect evidence from. When provided, projectId, ciBuildId, and branch are ignored."
+    ),
+  ciBuildId: z
+    .string()
+    .optional()
+    .describe(
+      "CI build ID for exact run lookup. Requires projectId. Takes precedence over branch."
+    ),
+  branch: z
+    .string()
+    .optional()
+    .describe(
+      "Git branch name. The most recent completed run on this branch is used. Requires projectId."
+    ),
+  spec: z
+    .string()
+    .optional()
+    .describe(
+      "Filter spec files by substring match on the spec file path (case-insensitive)."
+    ),
+  testTitle: z
+    .string()
+    .optional()
+    .describe(
+      "Filter tests by substring match on the full test title, including describe blocks (case-insensitive)."
+    ),
+  testStatus: z
+    .array(z.enum(["passed", "failed", "pending", "skipped"]))
+    .optional()
+    .describe("Filter tests by status. When omitted, all tests are included."),
+  maxInstances: z
+    .number()
+    .int()
+    .min(1)
+    .max(25)
+    .optional()
+    .describe(
+      "Maximum number of spec file instances to fetch artifacts for (default: 10, max: 25). Narrow with the spec filter instead of raising this."
+    ),
+});
+
+interface AssetRef {
+  name?: string;
+  attempt: number | null;
+  url: string;
+}
+
+interface AttachmentRef extends AssetRef {
+  filename?: string;
+  contentType?: string;
+}
+
+interface TestEvidence {
+  screenshots: AssetRef[];
+  videos: AssetRef[];
+  traces: AssetRef[];
+  attachments: AttachmentRef[];
+}
+
+interface EvidenceTest {
+  testId: string;
+  title: string;
+  status: string | null;
+  evidence: TestEvidence;
+}
+
+const emptyEvidence = (): TestEvidence => ({
+  screenshots: [],
+  videos: [],
+  traces: [],
+  attachments: [],
+});
+
+const hasEvidence = (e: TestEvidence): boolean =>
+  e.screenshots.length > 0 ||
+  e.videos.length > 0 ||
+  e.traces.length > 0 ||
+  e.attachments.length > 0;
+
+/**
+ * Groups the flat artifact arrays of an instance payload
+ * (results.screenshots, results.videos, results.playwrightTraces,
+ * results.attachments) by testId. Artifacts without a testId (e.g. Cypress
+ * spec-level artifacts) land under the "" key.
+ */
+function groupArtifactsByTest(results: any): Map<string, TestEvidence> {
+  const byTest = new Map<string, TestEvidence>();
+  const groupFor = (testId: string | undefined): TestEvidence => {
+    const key = testId ?? "";
+    let group = byTest.get(key);
+    if (!group) {
+      group = emptyEvidence();
+      byTest.set(key, group);
+    }
+    return group;
+  };
+
+  for (const s of results?.screenshots ?? []) {
+    if (!s.screenshotURL) continue;
+    groupFor(s.testId).screenshots.push({
+      name: s.name ?? undefined,
+      attempt: s.testAttemptIndex ?? null,
+      url: s.screenshotURL,
+    });
+  }
+  for (const v of results?.videos ?? []) {
+    if (!v.videoUrl) continue;
+    groupFor(v.testId).videos.push({
+      attempt: v.testAttemptIndex ?? null,
+      url: v.videoUrl,
+    });
+  }
+  for (const t of results?.playwrightTraces ?? []) {
+    if (!t.traceURL) continue;
+    groupFor(t.testId).traces.push({
+      name: t.name ?? undefined,
+      attempt: t.testAttemptIndex ?? null,
+      url: t.traceURL,
+    });
+  }
+  for (const a of results?.attachments ?? []) {
+    if (!a.readUrl) continue;
+    groupFor(a.testId).attachments.push({
+      name: a.name ?? undefined,
+      filename: a.filename ?? undefined,
+      contentType: a.contentType ?? undefined,
+      attempt: a.testAttemptIndex ?? null,
+      url: a.readUrl,
+    });
+  }
+  return byTest;
+}
+
+const handler = async ({
+  projectId,
+  runId,
+  ciBuildId,
+  branch,
+  spec,
+  testTitle,
+  testStatus,
+  maxInstances = 10,
+}: z.infer<typeof zodSchema>) => {
+  const fail = (text: string) => ({
+    content: [{ type: "text" as const, text }],
+  });
+
+  if (!runId && !projectId) {
+    return fail(
+      "Either runId or projectId is required. Provide runId directly, or projectId with optional ciBuildId/branch to locate the run."
+    );
+  }
+
+  // Resolve the run
+  let resolvedRunId = runId;
+  if (!resolvedRunId) {
+    const queryParams = new URLSearchParams();
+    queryParams.append("projectId", projectId as string);
+    if (ciBuildId) queryParams.append("ciBuildId", ciBuildId);
+    if (branch) queryParams.append("branch", branch);
+    const found = await fetchApi<{ data?: { runId?: string } }>(
+      `/runs/find?${queryParams.toString()}`
+    );
+    resolvedRunId = found?.data?.runId;
+    if (!resolvedRunId) {
+      return fail(
+        `No run found for projectId=${projectId}${
+          ciBuildId ? ` ciBuildId=${ciBuildId}` : ""
+        }${branch ? ` branch=${branch}` : ""}. The CI run may not have started reporting to Currents yet.`
+      );
+    }
+  }
+
+  const runResponse = await fetchApi<{ data?: any }>(`/runs/${resolvedRunId}`);
+  const run = runResponse?.data;
+  if (!run) {
+    return fail(`Failed to retrieve run ${resolvedRunId}`);
+  }
+
+  const allSpecs: any[] = run.specs ?? [];
+  const specFilter = spec?.toLowerCase();
+  const matchingSpecs = specFilter
+    ? allSpecs.filter((s) => (s.spec ?? "").toLowerCase().includes(specFilter))
+    : allSpecs;
+
+  if (matchingSpecs.length === 0) {
+    const available = allSpecs.map((s) => s.spec).join("\n");
+    return fail(
+      spec
+        ? `No spec files matching "${spec}" in run ${resolvedRunId}. Spec files in this run:\n${available}`
+        : `Run ${resolvedRunId} has no spec files.`
+    );
+  }
+
+  const selectedSpecs = matchingSpecs.slice(0, maxInstances);
+
+  logger.info(
+    `Collecting evidence from run ${resolvedRunId}: ${selectedSpecs.length}/${matchingSpecs.length} spec instances`
+  );
+
+  const titleFilter = testTitle?.toLowerCase();
+  const statusFilter = testStatus && testStatus.length > 0 ? testStatus : null;
+
+  const specs = await Promise.all(
+    selectedSpecs.map(async (specEntry) => {
+      const instanceResponse = await fetchApi<{ data?: any }>(
+        `/instances/${specEntry.instanceId}`
+      );
+      const results = instanceResponse?.data?.results;
+      if (!results) {
+        return {
+          spec: specEntry.spec,
+          instanceId: specEntry.instanceId,
+          error: "Failed to retrieve instance data",
+        };
+      }
+
+      const artifactsByTest = groupArtifactsByTest(results);
+
+      const tests: EvidenceTest[] = (results.tests ?? [])
+        .map((t: any): EvidenceTest => {
+          const title = Array.isArray(t.title)
+            ? t.title.join(" > ")
+            : String(t.title ?? "");
+          return {
+            testId: t.testId,
+            title,
+            // InstanceTest V2 entries carry no state
+            status: t.state ?? null,
+            evidence: artifactsByTest.get(t.testId) ?? emptyEvidence(),
+          };
+        })
+        .filter((t: EvidenceTest) => {
+          if (titleFilter && !t.title.toLowerCase().includes(titleFilter)) {
+            return false;
+          }
+          if (statusFilter && (!t.status || !statusFilter.includes(t.status as any))) {
+            return false;
+          }
+          return true;
+        });
+
+      // Spec-level artifacts: Cypress spec video plus any artifact with no testId
+      const specLevel = artifactsByTest.get("") ?? emptyEvidence();
+      if (results.videoUrl) {
+        specLevel.videos.push({ attempt: null, url: results.videoUrl });
+      }
+
+      return {
+        spec: specEntry.spec,
+        instanceId: specEntry.instanceId,
+        tests,
+        ...(hasEvidence(specLevel) ? { specLevelEvidence: specLevel } : {}),
+      };
+    })
+  );
+
+  const manifest = {
+    run: {
+      runId: resolvedRunId,
+      projectId: run.projectId ?? projectId,
+      ciBuildId: run.meta?.ciBuildId,
+      branch: run.meta?.commit?.branch,
+      commitSha: run.meta?.commit?.sha,
+      status: run.status,
+      createdAt: run.createdAt,
+      dashboardUrl: `https://app.currents.dev/run/${resolvedRunId}`,
+    },
+    specs,
+    ...(matchingSpecs.length > selectedSpecs.length
+      ? {
+          truncated: `Only the first ${selectedSpecs.length} of ${matchingSpecs.length} matching spec instances were fetched. Use the spec filter to narrow down, or raise maxInstances.`,
+        }
+      : {}),
+    note: "Artifact URLs are signed and time-limited. Download the files promptly (e.g. with curl) rather than storing the URLs.",
+  };
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(manifest, null, 2),
+      },
+    ],
+  };
+};
+
+export const getTestEvidenceTool = {
+  schema: zodSchema,
+  handler,
+};

--- a/skills/collect-ci-evidence/SKILL.md
+++ b/skills/collect-ci-evidence/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: collect-ci-evidence
+description: Collect evidence or a demo of an implemented feature from CI test runs via Currents — before/after screenshots, text output stored as test attachments, Playwright videos, traces, and GIFs. Use when asked to "collect evidence", "show proof", "demo the feature", "capture a before/after comparison", or to attach CI test artifacts to a PR, issue, or report. The evidence comes from tests running in CI (retrieved through the Currents MCP tools or REST API), not from local runs.
+---
+
+# Collect CI Evidence
+
+Produce verifiable evidence (or a demo) that a feature works by capturing artifacts in CI tests and retrieving them from Currents. Do not capture evidence locally: CI runs in a clean, reproducible environment, artifacts are stored and shareable, and this works even without a local browser.
+
+Evidence types and when to use each:
+
+| Evidence | Use for | Captured by |
+| --- | --- | --- |
+| Screenshot | Visual state, before/after UI comparison | `page.screenshot()` attached to the test |
+| Text/JSON attachment | CLI output, API responses, computed values, diffs | `testInfo.attach()` |
+| Video | Multi-step flows, interactions | Playwright/Cypress video recording |
+| Trace | Full replay with DOM, network, console | Playwright tracing |
+| GIF | Embedding a short demo in a PR/issue | Convert downloaded video with ffmpeg |
+
+## Requirements
+
+- The project reports CI test results to Currents (a Currents reporter is configured; runs appear in the dashboard).
+- Currents MCP server connected, or `CURRENTS_API_KEY` for REST calls to `https://api.currents.dev/v1`.
+
+## Workflow
+
+### 1. Instrument a test to capture the evidence
+
+Write or extend a test that exercises the feature and captures the artifact at the decisive moment. See [references/instrumentation.md](references/instrumentation.md) for Playwright and Cypress snippets and reporter configuration.
+
+Rules that make retrieval and pairing work later:
+
+- Name attachments deterministically (`evidence-order-summary.png`, not timestamped names). Before/after pairing matches on test title + attachment name.
+- One test per piece of evidence where practical; give the test a distinct, searchable title (e.g. include the word `evidence` or the feature name).
+- Keep screenshots deterministic: fixed viewport, disable animations, mask dynamic regions.
+
+### 2. Run in CI
+
+Push the branch (or open a PR) and let CI run with the Currents reporter. Note the branch name; if the workflow sets an explicit `ciBuildId`, note that too.
+
+For a before/after comparison, two runs are needed:
+
+- **before**: run on the base branch (often already exists — the latest `main` run works if the test exists there).
+- **after**: run on the feature branch.
+
+If the evidence test is new in the feature branch, it does not exist in the "before" run. In that case capture "before" by running the instrumented test against the base code (e.g. cherry-pick the test onto a throwaway branch off main and push it), or fall back to prose plus the "after" evidence.
+
+Wait for the run to finish before collecting (poll `currents-get-runs` / `currents-find-run` until status is not RUNNING).
+
+### 3. Collect from Currents
+
+Primary tool — `currents-get-test-evidence`:
+
+1. `currents-get-projects` if the projectId is unknown.
+2. `currents-get-test-evidence` with `projectId` + `branch` (or `ciBuildId`, or a known `runId`), plus `spec`/`testTitle` filters to narrow the output.
+3. The result is a manifest: per test, signed URLs grouped as `screenshots`, `videos`, `traces`, `attachments`, plus the run's `dashboardUrl`.
+
+Signed URLs expire. Download immediately:
+
+```bash
+curl -sL -o after-order-summary.png "<signed url>"
+```
+
+If `currents-get-test-evidence` is unavailable, compose primitives: `currents-find-run` → `currents-get-run-details` (specs → `instanceId`) → `currents-get-spec-instance` (artifact arrays live in `results`), or REST: `GET /runs/find`, `GET /runs/{runId}`, `GET /instances/{instanceId}`.
+
+### 4. Assemble and present
+
+- **Before/after**: call the evidence tool once per run (base branch and feature branch), pair artifacts by test title + attachment name, present side by side. For text attachments, download both and show a diff.
+- **GIF**: download the video, then `ffmpeg -i demo.webm -vf "fps=10,scale=720:-1" demo.gif`.
+- **Trace**: link the downloaded `trace.zip` and note it opens at https://trace.playwright.dev.
+- Always include the Currents `dashboardUrl` of the run(s) as the durable reference — downloaded URLs expire, the dashboard link does not.
+- When embedding in a PR or issue, upload the downloaded files (e.g. drag into the PR body or use the tracker's attachment API); do not paste signed URLs.
+
+## Troubleshooting
+
+- **No artifacts in the manifest**: the reporter did not capture them. Check Playwright config: `screenshot: "on"`, `video: "retain-on-failure"` (or `"on"` for passing-test demos), `trace: "on"` for the evidence run. `testInfo.attach()` works regardless of these settings.
+- **Videos/traces missing for passing tests**: `retain-on-failure` discards them on success. For demo evidence from passing tests, temporarily set `"on"` (scoped to the evidence spec via a test project) — or prefer screenshots and attachments, which are cheap to keep always on.
+- **Run not found**: the reporter may not have started, or CI is still queued. Verify the branch name and that the CI job actually ran the Currents-wrapped command.
+- **Expired URL when downloading**: re-run the evidence tool to get fresh signed URLs.

--- a/skills/collect-ci-evidence/references/instrumentation.md
+++ b/skills/collect-ci-evidence/references/instrumentation.md
@@ -30,10 +30,13 @@ before/after diffs — less unrelated churn. For full pages, fix the viewport in
 the config and mask dynamic regions:
 
 ```ts
-await page.screenshot({
-  fullPage: true,
-  animations: "disabled",
-  mask: [page.getByTestId("clock"), page.getByTestId("avatar")],
+await testInfo.attach("evidence-full-page.png", {
+  body: await page.screenshot({
+    fullPage: true,
+    animations: "disabled",
+    mask: [page.getByTestId("clock"), page.getByTestId("avatar")],
+  }),
+  contentType: "image/png",
 });
 ```
 

--- a/skills/collect-ci-evidence/references/instrumentation.md
+++ b/skills/collect-ci-evidence/references/instrumentation.md
@@ -1,0 +1,132 @@
+# Instrumenting tests to capture evidence
+
+Snippets for capturing evidence artifacts that Currents stores and the
+`currents-get-test-evidence` tool retrieves. Attachment names are the pairing
+key for before/after comparisons — keep them deterministic and stable.
+
+## Playwright
+
+### Screenshot evidence
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test("evidence: order summary shows applied discount", async ({ page }, testInfo) => {
+  await page.goto("/checkout");
+  await page.getByRole("button", { name: "Apply coupon" }).click();
+  await expect(page.getByTestId("order-summary")).toBeVisible();
+
+  await testInfo.attach("evidence-order-summary.png", {
+    body: await page.getByTestId("order-summary").screenshot({
+      animations: "disabled",
+    }),
+    contentType: "image/png",
+  });
+});
+```
+
+Element screenshots (`locator.screenshot()`) beat full-page screenshots for
+before/after diffs — less unrelated churn. For full pages, fix the viewport in
+the config and mask dynamic regions:
+
+```ts
+await page.screenshot({
+  fullPage: true,
+  animations: "disabled",
+  mask: [page.getByTestId("clock"), page.getByTestId("avatar")],
+});
+```
+
+### Text / JSON output as attachment
+
+For CLI output, API responses, or computed values — anything diffable:
+
+```ts
+test("evidence: pricing API returns discounted totals", async ({ request }, testInfo) => {
+  const response = await request.get("/api/cart/total?coupon=SAVE10");
+  const body = await response.json();
+
+  await testInfo.attach("evidence-cart-total.json", {
+    body: JSON.stringify(body, null, 2),
+    contentType: "application/json",
+  });
+
+  expect(body.total).toBe(90);
+});
+```
+
+Any file works the same way (`path` instead of `body`):
+
+```ts
+await testInfo.attach("evidence-report.txt", {
+  path: outputFilePath,
+  contentType: "text/plain",
+});
+```
+
+### Video and trace
+
+Controlled by `playwright.config.ts`. Defaults keep artifacts only for
+failures; demo evidence usually comes from passing tests, so scope an
+always-on policy to the evidence tests with a dedicated project:
+
+```ts
+export default defineConfig({
+  use: {
+    viewport: { width: 1280, height: 720 },
+    screenshot: "on",
+    video: "retain-on-failure",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "evidence",
+      testMatch: /.*evidence.*\.spec\.ts/,
+      use: { video: "on", trace: "on" },
+    },
+  ],
+});
+```
+
+The Currents reporter uploads screenshots, videos, traces, and attachments per
+attempt automatically — no extra reporter config.
+
+### GIF
+
+Playwright does not produce GIFs. Record a video, download it from the
+evidence manifest, then convert:
+
+```bash
+ffmpeg -i demo.webm -vf "fps=10,scale=720:-1" demo.gif
+```
+
+## Cypress
+
+Requires `cypress-cloud` for artifact reporting to Currents (note: Currents
+suspended integration for Cypress 13+ — verify version compatibility).
+
+```js
+it("evidence: order summary shows applied discount", () => {
+  cy.visit("/checkout");
+  cy.get("[data-testid=apply-coupon]").click();
+  cy.get("[data-testid=order-summary]").should("be.visible");
+  cy.screenshot("evidence-order-summary", { capture: "viewport" });
+});
+```
+
+- Screenshots upload with their given name; videos record per spec file
+  (`video: true` in `cypress.config.js`) and appear as spec-level evidence in
+  the manifest, not per test.
+- Text evidence: write it with `cy.writeFile()` and assert on it; there is no
+  per-test attachment API, so prefer screenshots or migrate text evidence
+  workflows to Playwright projects when possible.
+
+## Naming conventions
+
+- Prefix evidence artifacts with `evidence-` so they are easy to spot among
+  incidental screenshots and traces.
+- Same name in before and after runs; the run (branch/commit) distinguishes
+  them, not the file name.
+- Include the feature area in the test title (`"evidence: <feature> <claim>"`)
+  so `testTitle: "evidence"` filters the manifest to exactly the evidence
+  tests.

--- a/skills/collect-ci-evidence/references/instrumentation.md
+++ b/skills/collect-ci-evidence/references/instrumentation.md
@@ -71,6 +71,8 @@ failures; demo evidence usually comes from passing tests, so scope an
 always-on policy to the evidence tests with a dedicated project:
 
 ```ts
+import { defineConfig } from "@playwright/test";
+
 export default defineConfig({
   use: {
     viewport: { width: 1280, height: 720 },


### PR DESCRIPTION
# User description
## What changed

- New MCP tool `currents-get-test-evidence` (`mcp-server/src/tools/evidence/get-test-evidence.ts`): collects evidence artifacts (screenshots, videos, Playwright traces, attachments) from a CI run and returns a per-test manifest of signed download URLs. Resolves the run by `runId`, or by `projectId` + `ciBuildId`/`branch` via `/runs/find`. Supports `spec`, `testTitle`, and `testStatus` filters and a `maxInstances` cap. Spec-level artifacts (Cypress spec video, attachments without a testId) are reported separately from per-test evidence.
- New top-level `skills/` directory with a `collect-ci-evidence` agent skill: teaches agents to instrument tests to capture evidence (screenshot, text/JSON attachment, video, trace), run them in CI, collect artifacts through the Currents MCP tools, and assemble before/after comparisons, GIFs, and trace links. Includes Playwright/Cypress instrumentation snippets in `references/instrumentation.md`.
- README: regenerated tools table, new Skills section.

## Why

Evidence or a demo of an implemented feature (before/after screenshots, attached text output, videos) should come from CI via Currents rather than local runs. Today that requires chaining `find-run` → `get-run-details` → `get-spec-instance` and extracting artifacts from a payload shape that is absent from the published OpenAPI schema (`results.playwrightTraces`, `results.attachments`, etc. on `GET /instances/{id}`). The run payload only carries Cypress screenshots/video, and `GET /context` is failure-oriented. The new tool packages that chain into one call; the skill documents the end-to-end workflow.

## Notes for reviewers

- The tool is a single-run primitive; before/after comparison is done by calling it once per run (base branch vs feature branch), as the skill instructs.
- Artifacts are read from `GET /instances/{instanceId}` because it covers all frameworks, all attempts, and passing tests.
- Signed URL expiry is called out in both the tool output (`note` field) and the skill.
- Verified: `npm run build`, full vitest suite (422 tests), and `sync-readme-tools.mjs --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tool for retrieving CI test evidence, including screenshots, videos, traces, and attachments.
  * Added filtering by project, branch, test title, status, and spec file.
  * Added structured evidence details, run metadata, and guidance for accessing signed artifacts.

* **Documentation**
  * Added guidance for collecting CI evidence with Playwright and Cypress.
  * Documented setup, instrumentation, artifact retrieval, presentation, and troubleshooting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add the <code>currents-get-test-evidence</code> MCP tool to resolve CI runs, retrieve instance artifacts, and return filtered per-test manifests with signed URLs. Add the <code>collect-ci-evidence</code> skill and README guidance for instrumenting Playwright/Cypress tests and assembling CI-based evidence.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/currents-dev/currents-mcp/165?tool=ast&topic=Evidence+Collection+Skill>Evidence Collection Skill</a>
        </td><td>Document an end-to-end workflow for capturing and presenting CI evidence, including Playwright/Cypress instrumentation, signed URL handling, comparisons, GIFs, and traces.<details><summary>Modified files (3)</summary><ul><li>README.md</li>
<li>skills/collect-ci-evidence/SKILL.md</li>
<li>skills/collect-ci-evidence/references/instrumentation.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>agoldis@gmail.com</td><td>fix: attach full-page ...</td><td>August 16, 2026</td></tr>
<tr><td>miguelangaranocurrents</td><td>[] feat: remote mcp (#...</td><td>July 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/currents-dev/currents-mcp/165?tool=ast&topic=CI+Evidence+Retrieval>CI Evidence Retrieval</a>
        </td><td>Add <code>currents-get-test-evidence</code> to locate CI runs, collect screenshots, videos, traces, and attachments from all test instances, and group filtered artifacts by test or spec.<details><summary>Modified files (3)</summary><ul><li>mcp-server/src/server.ts</li>
<li>mcp-server/src/tools/evidence/get-test-evidence.test.ts</li>
<li>mcp-server/src/tools/evidence/get-test-evidence.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>agoldis@gmail.com</td><td>fix: honor ciBuildId p...</td><td>August 16, 2026</td></tr>
<tr><td>miguelangaranocurrents</td><td>[] feat: remote mcp (#...</td><td>July 14, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/currents-dev/currents-mcp/165?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>