### PR TITLE
ci: add skip_deploy input to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,11 @@ on:
           - alpha
           - beta
           - latest
+      skip_deploy:
+        required: false
+        type: boolean
+        default: false
+        description: Skip the deploy notification to the private infra repo (the image is still pushed to GHCR)
 
 permissions:
   id-token: write
@@ -134,7 +139,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Notify private MCP deploy pipeline
-        if: github.event.inputs.channel == 'latest' || github.event.inputs.channel == 'beta'
+        if: (github.event.inputs.channel == 'latest' || github.event.inputs.channel == 'beta') && inputs.skip_deploy != true
         env:
           DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |


### PR DESCRIPTION
# User description
## What changed

Adds an optional `skip_deploy` boolean input (default `false`) to the **Publish NPM Package** workflow. When enabled, the "Notify private MCP deploy pipeline" step is skipped for `beta`/`latest` publishes; the npm publish and the GHCR Docker image push are unchanged.

## Why

Publishing to `beta`/`latest` currently always dispatches a deployment of the hosted remote MCP endpoint to the private infra repo. Sometimes an npm release should go out without touching the hosted deployment — e.g. publishing a release that shouldn't roll the remote endpoint yet. This makes that a checkbox on the workflow run instead of a workflow edit.

## Notes for reviewers

- `inputs.skip_deploy` is used (typed boolean) rather than `github.event.inputs.skip_deploy` (string) in the step condition.
- Default behavior is identical to today: deploy notification fires for `beta`/`latest` unless the box is checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add an optional typed <code>skip_deploy</code> input to the Publish NPM Package workflow and use it to conditionally suppress the private MCP deployment notification. Keep npm publishing and GHCR image pushes unchanged, with deployment notifications remaining enabled by default for <code>beta</code> and <code>latest</code>.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>agoldis@gmail.com</td><td>ci: add skip_deploy in...</td><td>August 16, 2026</td></tr>
<tr><td>miguelangaranocurrents</td><td>[] feat: remote mcp (#...</td><td>July 14, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/currents-dev/currents-mcp/166?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>