### PR TITLE
chore: sync release 2.4.0 back to main

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# [2.4.0](https://github.com/currents-dev/currents-mcp/compare/v2.3.3...v2.4.0) (2026-08-16)
+
+### Bug Fixes
+
+* attach full-page screenshot in skill example ([4223659](https://github.com/currents-dev/currents-mcp/commit/42236599fc96db75d84209129dcbbed7b9e54f97))
+* honor ciBuildId precedence over branch in evidence run lookup ([3467ea9](https://github.com/currents-dev/currents-mcp/commit/3467ea916df0810df40422d2d878f1b27d03bda6))
+
+### Features
+
+* add currents-get-test-evidence tool and collect-ci-evidence skill ([35a665f](https://github.com/currents-dev/currents-mcp/commit/35a665f95bef995b98d79f9689fcce9aac11ed6c))
+
 ## Unreleased (2026-06-12)
 
 ### Added

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@currents/mcp",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@currents/mcp",
-      "version": "2.3.3",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -17,7 +17,7 @@
     "mcp": "./dist/index.mjs",
     "currents-mcp-http": "./dist/http.mjs"
   },
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "Currents MCP server",
   "main": "./dist/api.cjs",
   "module": "./dist/api.mjs",


### PR DESCRIPTION
# User description
Merges the `chore: release v2.4.0` commit (version bump + changelog) from `release/2.4.0` back into `main`, following the same pattern as previous releases (#137, #135, #96).

## Why this is needed before the next release

The `v2.4.0` tag and its release commit live only on `release/2.4.0` — they are not reachable from `main`. Right now `main` still has `"version": "2.3.3"` in `mcp-server/package.json` and no 2.4.0 changelog entry.

If we cut `release/2.5.0` from `main` as-is, release-it sees `v2.3.3` as the latest reachable tag and computes the next version as **2.4.0 again**, colliding with the tag that already exists.

Merging this first makes `v2.4.0` reachable from `main`, so the next release correctly computes 2.5.0 from the feature commits in #167.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Sync the Currents MCP server’s <code>2.4.0</code> release metadata and changelog to <code>main</code>. Update package manifests and document the release features and fixes so future release tooling can correctly calculate <code>2.5.0</code>.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/currents-dev/currents-mcp/168?tool=ast&topic=Release+Version+Sync>Release Version Sync</a>
        </td><td>Update the MCP server version in package manifests and lockfile to make <code>v2.4.0</code> reachable for subsequent release calculation.<details><summary>Modified files (2)</summary><ul><li>mcp-server/package-lock.json</li>
<li>mcp-server/package.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>github-actions[bot]@us...</td><td>chore: release v2.4.0</td><td>August 16, 2026</td></tr>
<tr><td>miguelangaranocurrents</td><td>[] feat: remote mcp (#...</td><td>July 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/currents-dev/currents-mcp/168?tool=ast&topic=Release+Changelog>Release Changelog</a>
        </td><td>Document the <code>2.4.0</code> release, including the evidence tool, skill, and bug fixes.<details><summary>Modified files (1)</summary><ul><li>mcp-server/CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>github-actions[bot]@us...</td><td>chore: release v2.4.0</td><td>August 16, 2026</td></tr>
<tr><td>github-actions[bot]</td><td>Add currents-link-jira...</td><td>June 15, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/currents-dev/currents-mcp/168?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>