### PR TITLE
ci: add increment input to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,15 @@ on:
         description: "Dry run (no actual release)"
         type: boolean
         default: false
+      increment:
+        description: "Version increment. auto derives it from the conventional commits since the last tag."
+        type: choice
+        default: auto
+        options:
+          - auto
+          - patch
+          - minor
+          - major
 
 jobs:
   release:
@@ -36,6 +45,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Release
-        run: npx release-it --ci ${{ inputs.dry_run && '--dry-run' || '' }}
+        run: npx release-it ${{ inputs.increment != 'auto' && inputs.increment || '' }} --ci ${{ inputs.dry_run && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# User description
## What changed

Adds an optional `increment` choice input (`auto` | `patch` | `minor` | `major`, default `auto`) to the **Create Release** workflow. When it is not `auto`, the value is passed to release-it as an explicit increment, overriding what the conventional-changelog plugin would derive.

## Why

2.4.0 was published to `beta` and never promoted to `latest`, so the whole 2.4.x line is still unreleased in practice. The next beta should be **2.4.1**, but the commits since `v2.4.0` include `feat:` (#167), so release-it would compute 2.5.0 and burn a minor version that no user ever saw.

## Notes for reviewers

- Default behavior is unchanged: `auto` passes no increment argument, exactly as today.
- `${{ inputs.increment != 'auto' && inputs.increment || '' }}` renders the increment when set and an empty string for `auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add an optional version increment selector to the Create Release workflow and pass explicit <code>patch</code>, <code>minor</code>, or <code>major</code> values to <code>release-it</code>, while preserving automatic conventional-commit-based versioning by default.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>agoldis@gmail.com</td><td>ci: add increment inpu...</td><td>August 16, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/currents-dev/currents-mcp/169?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>