### PR TITLE
chore: sync releases 2.4.1 and 2.4.2 back to main

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.4.1](https://github.com/currents-dev/currents-mcp/compare/v2.4.0...v2.4.1) (2026-08-16)
+
+### Bug Fixes
+
+* build the skills into the docker image ([58a58b6](https://github.com/currents-dev/currents-mcp/commit/58a58b65a669e22f95c9ffbc70584bbd4334b747))
+
+### Features
+
+* serve agent skills as MCP resources ([adf1e00](https://github.com/currents-dev/currents-mcp/commit/adf1e00808404a03b5bdb1addd6cfe6320b182cd))
+
 # [2.4.0](https://github.com/currents-dev/currents-mcp/compare/v2.3.3...v2.4.0) (2026-08-16)
 
 ### Bug Fixes

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [2.4.2](https://github.com/currents-dev/currents-mcp/compare/v2.4.1...v2.4.2) (2026-08-16)
+
 ## [2.4.1](https://github.com/currents-dev/currents-mcp/compare/v2.4.0...v2.4.1) (2026-08-16)
 
 ### Bug Fixes

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@currents/mcp",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@currents/mcp",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@currents/mcp",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@currents/mcp",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -17,7 +17,7 @@
     "mcp": "./dist/index.mjs",
     "currents-mcp-http": "./dist/http.mjs"
   },
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Currents MCP server",
   "main": "./dist/api.cjs",
   "module": "./dist/api.mjs",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -17,7 +17,7 @@
     "mcp": "./dist/index.mjs",
     "currents-mcp-http": "./dist/http.mjs"
   },
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Currents MCP server",
   "main": "./dist/api.cjs",
   "module": "./dist/api.mjs",


### PR DESCRIPTION
# User description
Merges the `chore: release v2.4.1` and `chore: release v2.4.2` commits back into `main`, following the same pattern as #168 and earlier releases.

## What this brings to main

- `mcp-server/package.json` version 2.4.0 → 2.4.2
- CHANGELOG entries for 2.4.1 and 2.4.2
- Makes the `v2.4.1` and `v2.4.2` tags reachable from `main`

## Why it matters

`release/2.4.1` was never merged back, so `main` still says 2.4.0 and its newest reachable tag is `v2.4.0`. Cutting the next release branch from `main` in that state makes release-it compute a version that already exists — the same collision that #168 was opened to prevent.

No code changes; both commits are release bookkeeping only.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Synchronize the MCP server release metadata to version 2.4.2 and record releases 2.4.1 and 2.4.2 in the changelog. Update <code>package.json</code> and <code>package-lock.json</code> so release tooling and package consumers recognize the releases, without changing application code.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/currents-dev/currents-mcp/171?tool=ast&topic=Release+History>Release History</a>
        </td><td>Document releases <code>2.4.1</code> and <code>2.4.2</code>, including the skills-related fixes and features, and make the release history reachable from <code>main</code>.<details><summary>Modified files (1)</summary><ul><li>mcp-server/CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>github-actions[bot]@us...</td><td>chore: release v2.4.2</td><td>August 16, 2026</td></tr>
<tr><td>github-actions[bot]</td><td>Add currents-link-jira...</td><td>June 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/currents-dev/currents-mcp/171?tool=ast&topic=Release+Versioning>Release Versioning</a>
        </td><td>Update the MCP server package and lockfile versions to <code>2.4.2</code> so <code>main</code> reflects the latest release and release tooling can calculate future versions correctly.<details><summary>Modified files (2)</summary><ul><li>mcp-server/package-lock.json</li>
<li>mcp-server/package.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>github-actions[bot]@us...</td><td>chore: release v2.4.2</td><td>August 16, 2026</td></tr>
<tr><td>miguelangaranocurrents</td><td>[] feat: remote mcp (#...</td><td>July 14, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/currents-dev/currents-mcp/171?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>