### PR TITLE
ci: open the sync PR to main automatically after a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -48,3 +49,32 @@ jobs:
         run: npx release-it ${{ inputs.increment != 'auto' && inputs.increment || '' }} --ci ${{ inputs.dry_run && '--dry-run' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # The release commit (version bump + changelog) is made on the release
+      # branch. Until it reaches main, main's newest reachable tag is the
+      # previous release, and the next release computes a version that already
+      # exists.
+      - name: Open sync PR to main
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          BRANCH="${{ github.ref_name }}"
+          VERSION=$(node -p "require('./package.json').version")
+
+          EXISTING=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Sync PR already open for $BRANCH: #$EXISTING"
+            exit 0
+          fi
+
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: sync release $VERSION back to main" \
+            --body "$(printf '%s\n' \
+              "Merges the \`chore: release v$VERSION\` commit (version bump + changelog) back into \`main\`." \
+              "" \
+              "Opened automatically by the Create Release workflow. Without it, \`main\` keeps the previous version and the next release branch computes a version that already exists." \
+              "" \
+              "No code changes - release bookkeeping only.")"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,8 +69,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCH: ${{ github.ref_name }}
+          RELEASE_REF_TYPE: ${{ github.ref_type }}
         run: |
           set -euo pipefail
+
+          # A tag can be named release/x.y.z and would pass the branch check.
+          if [ "$RELEASE_REF_TYPE" != "branch" ]; then
+            echo "Dispatched from a $RELEASE_REF_TYPE, skipping sync PR."
+            exit 0
+          fi
 
           # Read the ref as data, never as shell source: a branch name is
           # attacker-controlled by anyone with write access.
@@ -84,6 +91,14 @@ jobs:
           # Nothing to sync unless release-it actually made the release commit.
           if [ "$(git log -1 --pretty=%s)" != "chore: release v$VERSION" ]; then
             echo "No release commit on HEAD, skipping sync PR."
+            exit 0
+          fi
+
+          # release-it commits before it pushes. If the push failed, the commit
+          # exists only on the runner and a PR would not contain it.
+          REMOTE_HEAD=$(git ls-remote origin "refs/heads/$RELEASE_BRANCH" | cut -f1 || true)
+          if [ "$REMOTE_HEAD" != "$(git rev-parse HEAD)" ]; then
+            echo "Release commit is not on origin/$RELEASE_BRANCH, skipping sync PR."
             exit 0
           fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,13 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+
+    # The sync PR is opened with a list-then-create pair, which is not atomic.
+    # Serializing runs per ref keeps two of them from opening duplicates.
+    concurrency:
+      group: release-sync-${{ github.ref }}
+      cancel-in-progress: false
+
     defaults:
       run:
         working-directory: ./mcp-server
@@ -55,22 +62,38 @@ jobs:
       # previous release, and the next release computes a version that already
       # exists.
       - name: Open sync PR to main
-        if: ${{ !inputs.dry_run }}
+        # Also runs when the release step failed: release-it pushes the commit
+        # and tag before it creates the GitHub release, so a late failure still
+        # leaves a release commit that main needs.
+        if: ${{ !cancelled() && !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
-          BRANCH="${{ github.ref_name }}"
-          VERSION=$(node -p "require('./package.json').version")
-
-          EXISTING=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number // empty')
-          if [ -n "$EXISTING" ]; then
-            echo "Sync PR already open for $BRANCH: #$EXISTING"
+          # Read the ref as data, never as shell source: a branch name is
+          # attacker-controlled by anyone with write access.
+          if ! printf '%s' "$RELEASE_BRANCH" | grep -Eq '^release/[A-Za-z0-9._-]+$'; then
+            echo "Not a release branch, skipping sync PR: $RELEASE_BRANCH"
             exit 0
           fi
 
-          gh pr create --base main --head "$BRANCH" \
+          VERSION=$(node -p "require('./package.json').version")
+
+          # Nothing to sync unless release-it actually made the release commit.
+          if [ "$(git log -1 --pretty=%s)" != "chore: release v$VERSION" ]; then
+            echo "No release commit on HEAD, skipping sync PR."
+            exit 0
+          fi
+
+          EXISTING=$(gh pr list --head "$RELEASE_BRANCH" --base main --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Sync PR already open for $RELEASE_BRANCH: #$EXISTING"
+            exit 0
+          fi
+
+          gh pr create --base main --head "$RELEASE_BRANCH" \
             --title "chore: sync release $VERSION back to main" \
             --body "$(printf '%s\n' \
               "Merges the \`chore: release v$VERSION\` commit (version bump + changelog) back into \`main\`." \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,19 +21,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
-    # The sync PR is opened with a list-then-create pair, which is not atomic.
-    # Serializing runs per ref keeps two of them from opening duplicates.
-    concurrency:
-      group: release-sync-${{ github.ref }}
-      cancel-in-progress: false
-
     defaults:
       run:
         working-directory: ./mcp-server
 
     permissions:
       contents: write
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -57,15 +50,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # The release commit (version bump + changelog) is made on the release
-      # branch. Until it reaches main, main's newest reachable tag is the
-      # previous release, and the next release computes a version that already
-      # exists.
+  # The release commit (version bump + changelog) is made on the release
+  # branch. Until it reaches main, main's newest reachable tag is the previous
+  # release, and the next release computes a version that already exists.
+  #
+  # Separate job on purpose: `pull-requests: write` must not be in scope while
+  # release-it runs the repository's own test suite through its before:init
+  # hook. Nothing here executes repository code.
+  sync-pr:
+    needs: release
+    # Also runs when the release job failed: release-it pushes the commit and
+    # tag before it creates the GitHub release, so a late failure still leaves
+    # a release commit that main needs.
+    if: ${{ !cancelled() && !inputs.dry_run }}
+    runs-on: ubuntu-latest
+
+    # The sync PR is opened with a list-then-create pair, which is not atomic.
+    # Serializing runs per ref keeps two of them from opening duplicates.
+    concurrency:
+      group: release-sync-${{ github.ref }}
+      cancel-in-progress: false
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Open sync PR to main
-        # Also runs when the release step failed: release-it pushes the commit
-        # and tag before it creates the GitHub release, so a late failure still
-        # leaves a release commit that main needs.
-        if: ${{ !cancelled() && !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCH: ${{ github.ref_name }}
@@ -99,7 +114,14 @@ jobs:
           fi
 
           git fetch --quiet --tags origin "$RELEASE_BRANCH"
-          VERSION=$(git show "$REMOTE_TIP:mcp-server/package.json" | jq -r .version)
+          VERSION=$(git show "$REMOTE_TIP:mcp-server/package.json" | jq -r '.version // ""')
+
+          # jq yields "null" for a missing or non-string version, which would
+          # otherwise reach the tag ref and the PR body.
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$'; then
+            echo "Unexpected version at the branch tip, skipping sync PR."
+            exit 0
+          fi
 
           # The release is only real once its tag is pushed and contained in
           # the branch. Ancestry, not equality: the branch may have moved on.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,24 +81,30 @@ jobs:
 
           # Read the ref as data, never as shell source: a branch name is
           # attacker-controlled by anyone with write access.
-          if ! printf '%s' "$RELEASE_BRANCH" | grep -Eq '^release/[A-Za-z0-9._-]+$'; then
+          # `+` is legal in a semver build version and release-it accepts the
+          # branch, so the allowlist has to allow it too.
+          if ! printf '%s' "$RELEASE_BRANCH" | grep -Eq '^release/[A-Za-z0-9.+_-]+$'; then
             echo "Not a release branch, skipping sync PR: $RELEASE_BRANCH"
             exit 0
           fi
 
-          VERSION=$(node -p "require('./package.json').version")
-
-          # Nothing to sync unless release-it actually made the release commit.
-          if [ "$(git log -1 --pretty=%s)" != "chore: release v$VERSION" ]; then
-            echo "No release commit on HEAD, skipping sync PR."
+          # Decide from the remote branch rather than the runner's checkout: a
+          # re-run of this workflow checks out the dispatch sha, which predates
+          # the release commit, and the PR is opened from the remote branch
+          # anyway.
+          REMOTE_TIP=$(git ls-remote origin "refs/heads/$RELEASE_BRANCH" | cut -f1 || true)
+          if [ -z "$REMOTE_TIP" ]; then
+            echo "No origin/$RELEASE_BRANCH, skipping sync PR."
             exit 0
           fi
 
-          # release-it commits before it pushes. If the push failed, the commit
-          # exists only on the runner and a PR would not contain it.
-          REMOTE_HEAD=$(git ls-remote origin "refs/heads/$RELEASE_BRANCH" | cut -f1 || true)
-          if [ "$REMOTE_HEAD" != "$(git rev-parse HEAD)" ]; then
-            echo "Release commit is not on origin/$RELEASE_BRANCH, skipping sync PR."
+          git fetch --quiet --tags origin "$RELEASE_BRANCH"
+          VERSION=$(git show "$REMOTE_TIP:mcp-server/package.json" | jq -r .version)
+
+          # The release is only real once its tag is pushed and contained in
+          # the branch. Ancestry, not equality: the branch may have moved on.
+          if ! git merge-base --is-ancestor "refs/tags/v$VERSION" "$REMOTE_TIP" 2>/dev/null; then
+            echo "v$VERSION is not on origin/$RELEASE_BRANCH, skipping sync PR."
             exit 0
           fi
 


### PR DESCRIPTION
# User description
## What changed

Adds a final step to the **Create Release** workflow that opens the `release/x.y.z` → `main` sync PR automatically, right after release-it creates the release commit and tag. Also grants the job `pull-requests: write`.

The step is a no-op on dry runs, and exits quietly if a sync PR for that branch is already open, so re-running the workflow will not create duplicates.

## Why

The release commit (version bump + changelog) is created on the release branch and nothing brings it back to `main`. While it is missing, `main`'s newest reachable tag is the *previous* release, so cutting the next release branch makes release-it compute a version that already exists.

This bit us twice in one session:

- `release/2.4.0` was never merged back, so `main` sat at 2.4.0 while a patch bump would have recomputed a taken version — #168 fixed it manually.
- `release/2.4.1` and `release/2.4.2` were both left behind, needing #171.

## Notes for reviewers

- The PR body is built with `printf` rather than a multi-line YAML string, so the workflow indentation does not leak into the body and turn it into markdown code blocks (verified locally).
- Uses the default `GITHUB_TOKEN`. If the repo or org has "Allow GitHub Actions to create and approve pull requests" disabled, this step will fail and that setting needs enabling — the rest of the release is already complete by then, so a failure here is recoverable by opening the PR by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a <code>sync-pr</code> job to the Create Release workflow to open a release-branch-to-<code>main</code> pull request after release-it pushes the release commit and tag. Validate the branch, version, and tag, grant <code>pull-requests: write</code>, and make the operation safe for dry runs, reruns, failed releases, and existing pull requests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/currents-dev/currents-mcp/172?tool=ast&topic=Release+sync+PR>Release sync PR</a>
        </td><td>Automatically open a validated sync pull request from the release branch to <code>main</code>, ensuring release bookkeeping reaches <code>main</code> without creating duplicates.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/release.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>agoldis@gmail.com</td><td>ci: isolate pull-reque...</td><td>August 16, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/currents-dev/currents-mcp/172?tool=ast&topic=Workflow+safeguards>Workflow safeguards</a>
        </td><td>Harden the <code>sync-pr</code> job with branch and version validation, tag ancestry checks, concurrency control, remote-tip lookup, and least-privilege permissions.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/release.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>agoldis@gmail.com</td><td>ci: isolate pull-reque...</td><td>August 16, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/currents-dev/currents-mcp/172?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>